### PR TITLE
depend on reach v1.6.0. add to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(reach REQUIRED)
 find_package(reach_ros REQUIRED)
 
 add_library(${PROJECT_NAME}_plugins SHARED)

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -14,4 +14,4 @@ repositories:
   reach_ros:
     type: git
     url: https://github.com/ros-industrial/reach_ros2.git
-    version: 1.3.4
+    version: 1.4.0


### PR DESCRIPTION
This PR changes the dependency on `reach` to v1.6.0 and adds `reach` to the CMakesList.txt file.

This was the only change required to successfully build.